### PR TITLE
Hotfix/device actions

### DIFF
--- a/custom_components/bond/__init__.py
+++ b/custom_components/bond/__init__.py
@@ -19,7 +19,7 @@ CONFIG_SCHEMA = vol.Schema({
 def setup(hass, config):
     """Your controller/hub specific code."""
 
-    from bond import Bond
+    from .bond import Bond
 
     # Assign configuration variables.
     # The configuration check takes care they are present.

--- a/custom_components/bond/bond.py
+++ b/custom_components/bond/bond.py
@@ -1,0 +1,60 @@
+import requests
+
+BOND_DEVICE_TYPE_CEILING_FAN = "CF"
+BOND_DEVICE_TYPE_FIREPLACE = "FP"
+BOND_DEVICE_TYPE_MOTORIZED_SHADES = "MS"
+BOND_DEVICE_TYPE_GENERIC_DEVICE = "GX"
+
+class Bond:
+    def __init__(self, bondIp, bondToken):
+        self.bondIp = bondIp
+        self.bondToken = bondToken
+
+    def setFanSpeed(self, deviceId, speed):
+        return self.doAction(deviceId, 'SetSpeed', {'argument': speed})
+
+    def turnFanOn(self, deviceId):
+        return self.doAction(deviceId, 'TurnOn')
+
+    def turnFanOff(self, deviceId):
+        return self.doAction(deviceId, 'TurnOff')
+
+    def toggleLight(self, deviceId):
+        return self.doAction(deviceId, 'ToggleLight')
+
+    def turnLightOn(self, deviceId):
+        return self.doAction(deviceId, 'TurnLightOn')
+
+    def turnLightOff(self, deviceId):
+        return self.doAction(deviceId, 'TurnLightOff')
+
+    def doAction(self, deviceId, action, payload={}):
+        print(f'http://{self.bondIp}/v2/devices/{deviceId}/actions/{action}')
+        print(payload)
+        r = requests.put(
+            f'http://{self.bondIp}/v2/devices/{deviceId}/actions/{action}', headers={'BOND-Token': self.bondToken}, json=payload)
+        return r.content
+
+    def getDeviceIds(self):
+        r = requests.get(f'http://{self.bondIp}/v2/devices',
+                         headers={'BOND-Token': self.bondToken})
+        devices = []
+        for key in r.json():
+            if (key != '_'):
+                devices.append(key)
+        return devices
+
+    def getDeviceType(self, deviceId):
+        r = requests.get(f'http://{self.bondIp}/v2/devices/{deviceId}',
+                         headers={'BOND-Token': self.bondToken})
+        return r.json()['type']
+
+    def getDevice(self, deviceId):
+        r = requests.get(f'http://{self.bondIp}/v2/devices/{deviceId}',
+                         headers={'BOND-Token': self.bondToken})
+        return r.json()
+
+    def getDeviceState(self, deviceId):
+        r = requests.get(f'http://{self.bondIp}/v2/devices/{deviceId}/state',
+                         headers={'BOND-Token': self.bondToken})
+        return r.json()

--- a/custom_components/bond/bond.py
+++ b/custom_components/bond/bond.py
@@ -5,6 +5,31 @@ BOND_DEVICE_TYPE_FIREPLACE = "FP"
 BOND_DEVICE_TYPE_MOTORIZED_SHADES = "MS"
 BOND_DEVICE_TYPE_GENERIC_DEVICE = "GX"
 
+# Note that Bond Action "Stop" instructs the Bond Bridge to stop sending.  There are other
+# actions such as "Hold" that send a message to stop the controlled-device's current action
+BOND_DEVICE_ACTION_STOP = "Stop"
+
+# Relating to Generic Device (GX)
+BOND_DEVICE_ACTION_TURNON = "TurnOn"
+BOND_DEVICE_ACTION_TURNOFF = "TurnOff"
+BOND_DEVICE_ACTION_TOGGLEPOWER = "TogglePower"
+
+# Relating to Motorized Shades (MS)
+BOND_DEVICE_ACTION_OPEN = "Open"
+BOND_DEVICE_ACTION_CLOSE = "Close"
+BOND_DEVICE_ACTION_HOLD = "Hold"
+BOND_DEVICE_ACTION_PAIR = "Pair"
+BOND_DEVICE_ACTION_PRESET = "Preset"
+BOND_DEVICE_ACTION_TOGGLEOPEN = "ToggleOpen"
+
+# Relating to Ceiling Fan (CF)
+BOND_DEVICE_ACTION_SETSPEED = "SetSpeed"
+BOND_DEVICE_ACTION_INCREASESPEED = "IncreaseSpeed"
+BOND_DEVICE_ACTION_DECREASESPEED = "DecreaseSpeed"
+BOND_DEVICE_ACTION_TURNLIGHTON = "TurnLightOn"
+BOND_DEVICE_ACTION_TURNLIGHTOFF = "TurnLightOff"
+BOND_DEVICE_ACTION_TOGGLELIGHT = "ToggleLight"
+
 class Bond:
     def __init__(self, bondIp, bondToken):
         self.bondIp = bondIp
@@ -19,6 +44,9 @@ class Bond:
     def turnFanOff(self, deviceId):
         return self.doAction(deviceId, 'TurnOff')
 
+    def setFanSpeed(self, deviceId, speed):
+        return self.doAction(deviceId, BOND_DEVICE_ACTION_SETSPEED, {"argument":speed} )
+
     def toggleLight(self, deviceId):
         return self.doAction(deviceId, 'ToggleLight')
 
@@ -29,10 +57,10 @@ class Bond:
         return self.doAction(deviceId, 'TurnLightOff')
 
     def doAction(self, deviceId, action, payload={}):
-        print(f'http://{self.bondIp}/v2/devices/{deviceId}/actions/{action}')
-        print(payload)
         r = requests.put(
             f'http://{self.bondIp}/v2/devices/{deviceId}/actions/{action}', headers={'BOND-Token': self.bondToken}, json=payload)
+        if r.status_code < 200 or r.status_code > 299:
+            raise Exception(r.content)
         return r.content
 
     def getDeviceIds(self):
@@ -48,6 +76,11 @@ class Bond:
         r = requests.get(f'http://{self.bondIp}/v2/devices/{deviceId}',
                          headers={'BOND-Token': self.bondToken})
         return r.json()['type']
+
+    def getProperties(self, deviceId):
+        r = requests.get(f'http://{self.bondIp}/v2/devices/{deviceId}/properties/',
+                         headers={'BOND-Token': self.bondToken})
+        return r.json()
 
     def getDevice(self, deviceId):
         r = requests.get(f'http://{self.bondIp}/v2/devices/{deviceId}',

--- a/custom_components/bond/fan.py
+++ b/custom_components/bond/fan.py
@@ -3,6 +3,10 @@ from homeassistant.components.fan import (FanEntity)
 import logging
 DOMAIN = 'bond'
 
+from .bond import (
+    BOND_DEVICE_TYPE_CEILING_FAN,
+)
+
 # Import the device class from the component that you want to support
 
 _LOGGER = logging.getLogger(__name__)
@@ -14,7 +18,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     bond = hass.data[DOMAIN]['bond_hub']
 
     # Add devices
-    add_entities(BondFan(bond, deviceId) for deviceId in bond.getDeviceIds())
+    for deviceId in bond.getDeviceIds():
+        if bond.getDeviceType(deviceId) == BOND_DEVICE_TYPE_CEILING_FAN:
+            add_entities( [ BondFan(bond, deviceId) ] )
 
 
 class BondFan(FanEntity):

--- a/custom_components/bond/fan.py
+++ b/custom_components/bond/fan.py
@@ -1,10 +1,23 @@
 """Bond Home Fan Integration"""
-from homeassistant.components.fan import (FanEntity)
+from homeassistant.components.fan import (
+    SUPPORT_SET_SPEED,
+    SPEED_LOW,
+    SPEED_MEDIUM,
+    SPEED_HIGH,
+    FanEntity
+)
 import logging
 DOMAIN = 'bond'
 
 from .bond import (
     BOND_DEVICE_TYPE_CEILING_FAN,
+    BOND_DEVICE_ACTION_SETSPEED,
+    BOND_DEVICE_ACTION_INCREASESPEED,
+    BOND_DEVICE_ACTION_DECREASESPEED,
+    BOND_DEVICE_ACTION_TURNON,
+    BOND_DEVICE_ACTION_TURNOFF,
+    BOND_DEVICE_ACTION_TOGGLEPOWER,
+
 )
 
 # Import the device class from the component that you want to support
@@ -22,7 +35,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         if bond.getDeviceType(deviceId) == BOND_DEVICE_TYPE_CEILING_FAN:
             add_entities( [ BondFan(bond, deviceId) ] )
 
-
 class BondFan(FanEntity):
     """Representation of an Bond Fan"""
 
@@ -30,10 +42,22 @@ class BondFan(FanEntity):
         """Initialize a Bond Fan"""
         self._bond = bond
         self._deviceId = deviceId
+        self._device = self._bond.getDevice(self._deviceId)
+        self._properties = self._bond.getProperties(self._deviceId)
+        self._speed_list = []
 
-        bondProperties = self._bond.getDevice(self._deviceId)
-
-        self._name = bondProperties['name']
+        if BOND_DEVICE_ACTION_SETSPEED in self._device['actions']:
+            if 'max_speed' in self._properties:
+                self._speed_high = int(self._properties['max_speed'])
+                self._speed_low = int(1)
+                self._speed_list.append(SPEED_LOW)
+                if self._speed_high > 2:
+                    self._speed_list.append(SPEED_MEDIUM)
+                    self._speed_medium = (self._speed_high + 1) // 2
+                    self._speed_list.append(SPEED_MEDIUM)
+                self._speed_list.append(SPEED_HIGH)
+                
+        self._name = self._device['name']
         self._state = None
 
     @property
@@ -46,6 +70,21 @@ class BondFan(FanEntity):
         """Return true if fan is on"""
         return self._state
 
+    @property
+    def speed_list(self) -> list:
+        """Get the list of available speeds."""
+        return self._speed_list
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        supported_features = 0
+
+        if BOND_DEVICE_ACTION_SETSPEED in self._device['actions']:
+            supported_features |= SUPPORT_SET_SPEED
+
+        return supported_features
+
     def turn_on(self, speed=None, **kwargs):
         """Instruct the fan to turn on"""
         self._bond.turnFanOn(self._deviceId)
@@ -53,6 +92,15 @@ class BondFan(FanEntity):
     def turn_off(self, **kwargs):
         """Instruct the fan to turn off"""
         self._bond.turnFanOff(self._deviceId)
+
+    def set_speed(self, speed: str) -> None:
+        """Set the speed of the fan."""
+        if speed == SPEED_HIGH:
+           self._bond.setFanSpeed(self._deviceId, self._speed_high)
+        elif speed == SPEED_MEDIUM:
+           self._bond.setFanSpeed(self._deviceId, self._speed_medium)
+        elif speed == SPEED_LOW:
+           self._bond.setFanSpeed(self._deviceId, self._speed_low)
 
     def update(self):
         """Fetch new state data for this fan

--- a/custom_components/bond/light.py
+++ b/custom_components/bond/light.py
@@ -4,6 +4,11 @@ from homeassistant.components.light import (
 import logging
 DOMAIN = 'bond'
 
+from .bond import (
+    BOND_DEVICE_TYPE_CEILING_FAN,
+)
+
+
 # Import the device class from the component that you want to support
 
 _LOGGER = logging.getLogger(__name__)
@@ -20,8 +25,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     #     return
 
     # Add devices
-    add_entities(BondLight(bond, deviceId) for deviceId in bond.getDeviceIds())
-
+    for deviceId in bond.getDeviceIds():
+        if bond.getDeviceType(deviceId) == BOND_DEVICE_TYPE_CEILING_FAN:
+            add_entities( [ BondLight(bond, deviceId) ] )
 
 class BondLight(Light):
     """Representation of an Bond Light."""


### PR DESCRIPTION
Added support for fan speed control.  Limitations - I have only supported the home assistant out of the box 3 speeds, low, medium and high.  These will be mapped to Bond Fan speeds as low = 1, high = whatever the highest is and medium = a sensible number in between.  This code is only tested on fans with 3 speeds.