### PR TITLE
Feature/generic devices

### DIFF
--- a/custom_components/bond/__init__.py
+++ b/custom_components/bond/__init__.py
@@ -37,5 +37,6 @@ def setup(hass, config):
 
     hass.helpers.discovery.load_platform('light', DOMAIN, {}, config)
     hass.helpers.discovery.load_platform('fan', DOMAIN, {}, config)
+    hass.helpers.discovery.load_platform('cover', DOMAIN, {}, config)
 
     return True

--- a/custom_components/bond/__init__.py
+++ b/custom_components/bond/__init__.py
@@ -38,5 +38,6 @@ def setup(hass, config):
     hass.helpers.discovery.load_platform('light', DOMAIN, {}, config)
     hass.helpers.discovery.load_platform('fan', DOMAIN, {}, config)
     hass.helpers.discovery.load_platform('cover', DOMAIN, {}, config)
+    hass.helpers.discovery.load_platform('switch', DOMAIN, {}, config)
 
     return True

--- a/custom_components/bond/__init__.py
+++ b/custom_components/bond/__init__.py
@@ -19,7 +19,7 @@ CONFIG_SCHEMA = vol.Schema({
 def setup(hass, config):
     """Your controller/hub specific code."""
 
-    from bond import Bond
+    from .bond import Bond
 
     # Assign configuration variables.
     # The configuration check takes care they are present.

--- a/custom_components/bond/bond.py
+++ b/custom_components/bond/bond.py
@@ -35,26 +35,23 @@ class Bond:
         self.bondIp = bondIp
         self.bondToken = bondToken
 
-    def setFanSpeed(self, deviceId, speed):
-        return self.doAction(deviceId, 'SetSpeed', {'argument': speed})
-
     def turnFanOn(self, deviceId):
-        return self.doAction(deviceId, 'TurnOn')
+        return self.doAction(deviceId, BOND_DEVICE_ACTION_TURNON)
 
     def turnFanOff(self, deviceId):
-        return self.doAction(deviceId, 'TurnOff')
+        return self.doAction(deviceId, BOND_DEVICE_ACTION_TURNOFF)
 
     def setFanSpeed(self, deviceId, speed):
         return self.doAction(deviceId, BOND_DEVICE_ACTION_SETSPEED, {"argument":speed} )
 
     def toggleLight(self, deviceId):
-        return self.doAction(deviceId, 'ToggleLight')
+        return self.doAction(deviceId, BOND_DEVICE_ACTION_TOGGLELIGHT)
 
     def turnLightOn(self, deviceId):
-        return self.doAction(deviceId, 'TurnLightOn')
+        return self.doAction(deviceId, BOND_DEVICE_ACTION_TURNLIGHTON)
 
     def turnLightOff(self, deviceId):
-        return self.doAction(deviceId, 'TurnLightOff')
+        return self.doAction(deviceId, BOND_DEVICE_ACTION_TURNLIGHTOFF)
 
     def doAction(self, deviceId, action, payload={}):
         r = requests.put(
@@ -72,18 +69,13 @@ class Bond:
                 devices.append(key)
         return devices
 
-    def getDeviceType(self, deviceId):
+    def getDevice(self, deviceId):
         r = requests.get(f'http://{self.bondIp}/v2/devices/{deviceId}',
-                         headers={'BOND-Token': self.bondToken})
-        return r.json()['type']
-
-    def getProperties(self, deviceId):
-        r = requests.get(f'http://{self.bondIp}/v2/devices/{deviceId}/properties/',
                          headers={'BOND-Token': self.bondToken})
         return r.json()
 
-    def getDevice(self, deviceId):
-        r = requests.get(f'http://{self.bondIp}/v2/devices/{deviceId}',
+    def getProperties(self, deviceId):
+        r = requests.get(f'http://{self.bondIp}/v2/devices/{deviceId}/properties/',
                          headers={'BOND-Token': self.bondToken})
         return r.json()
 

--- a/custom_components/bond/bond.py
+++ b/custom_components/bond/bond.py
@@ -1,0 +1,60 @@
+import requests
+
+BOND_DEVICE_TYPE_CEILING_FAN = "CF"
+BOND_DEVICE_TYPE_FIREPLACE = "FP"
+BOND_DEVICE_TYPE_MOTORIZED_SHADES = "MS"
+BOND_DEVICE_TYPE_GENERIC_DEVICE = "GX"
+
+class Bond:
+    def __init__(self, bondIp, bondToken):
+        self.bondIp = bondIp
+        self.bondToken = bondToken
+
+    def setFanSpeed(self, deviceId, speed):
+        return self.doAction(deviceId, 'SetSpeed', {'argument': speed})
+
+    def turnFanOn(self, deviceId):
+        return self.doAction(deviceId, 'TurnOn')
+
+    def turnFanOff(self, deviceId):
+        return self.doAction(deviceId, 'TurnOff')
+
+    def toggleLight(self, deviceId):
+        return self.doAction(deviceId, 'ToggleLight')
+
+    def turnLightOn(self, deviceId):
+        return self.doAction(deviceId, 'TurnLightOn')
+
+    def turnLightOff(self, deviceId):
+        return self.doAction(deviceId, 'TurnLightOff')
+
+    def doAction(self, deviceId, action, payload={}):
+        print(f'http://{self.bondIp}/v2/devices/{deviceId}/actions/{action}')
+        print(payload)
+        r = requests.put(
+            f'http://{self.bondIp}/v2/devices/{deviceId}/actions/{action}', headers={'BOND-Token': self.bondToken}, json=payload)
+        return r.content
+
+    def getDeviceIds(self):
+        r = requests.get(f'http://{self.bondIp}/v2/devices',
+                         headers={'BOND-Token': self.bondToken})
+        devices = []
+        for key in r.json():
+            if (key != '_'):
+                devices.append(key)
+        return devices
+
+    def getDeviceType(self, deviceId):
+        r = requests.get(f'http://{self.bondIp}/v2/devices/{deviceId}',
+                         headers={'BOND-Token': self.bondToken})
+        return r.json()['type']
+
+    def getDevice(self, deviceId):
+        r = requests.get(f'http://{self.bondIp}/v2/devices/{deviceId}',
+                         headers={'BOND-Token': self.bondToken})
+        return r.json()
+
+    def getDeviceState(self, deviceId):
+        r = requests.get(f'http://{self.bondIp}/v2/devices/{deviceId}/state',
+                         headers={'BOND-Token': self.bondToken})
+        return r.json()

--- a/custom_components/bond/bond.py
+++ b/custom_components/bond/bond.py
@@ -5,6 +5,31 @@ BOND_DEVICE_TYPE_FIREPLACE = "FP"
 BOND_DEVICE_TYPE_MOTORIZED_SHADES = "MS"
 BOND_DEVICE_TYPE_GENERIC_DEVICE = "GX"
 
+# Note that Bond Action "Stop" instructs the Bond Bridge to stop sending.  There are other
+# actions such as "Hold" that send a message to stop the controlled-device's current action
+BOND_DEVICE_ACTION_STOP = "Stop"
+
+# Relating to Generic Device (GX)
+BOND_DEVICE_ACTION_TURNON = "TurnOn"
+BOND_DEVICE_ACTION_TURNOFF = "TurnOff"
+BOND_DEVICE_ACTION_TOGGLEPOWER = "TogglePower"
+
+# Relating to Motorized Shades (MS)
+BOND_DEVICE_ACTION_OPEN = "Open"
+BOND_DEVICE_ACTION_CLOSE = "Close"
+BOND_DEVICE_ACTION_HOLD = "Hold"
+BOND_DEVICE_ACTION_PAIR = "Pair"
+BOND_DEVICE_ACTION_PRESET = "Preset"
+BOND_DEVICE_ACTION_TOGGLEOPEN = "ToggleOpen"
+
+# Relating to Ceiling Fan (CF)
+BOND_DEVICE_ACTION_SETSPEED = "SetSpeed"
+BOND_DEVICE_ACTION_INCREASESPEED = "IncreaseSpeed"
+BOND_DEVICE_ACTION_DECREASESPEED = "DecreaseSpeed"
+BOND_DEVICE_ACTION_TURNLIGHTON = "TurnLightOn"
+BOND_DEVICE_ACTION_TURNLIGHTOFF = "TurnLightOff"
+BOND_DEVICE_ACTION_TOGGLELIGHT = "ToggleLight"
+
 class Bond:
     def __init__(self, bondIp, bondToken):
         self.bondIp = bondIp
@@ -19,6 +44,9 @@ class Bond:
     def turnFanOff(self, deviceId):
         return self.doAction(deviceId, 'TurnOff')
 
+    def setFanSpeed(self, deviceId, speed):
+        return self.doAction(deviceId, BOND_DEVICE_ACTION_SETSPEED, {"argument":speed} )
+
     def toggleLight(self, deviceId):
         return self.doAction(deviceId, 'ToggleLight')
 
@@ -29,10 +57,10 @@ class Bond:
         return self.doAction(deviceId, 'TurnLightOff')
 
     def doAction(self, deviceId, action, payload={}):
-        print(f'http://{self.bondIp}/v2/devices/{deviceId}/actions/{action}')
-        print(payload)
         r = requests.put(
             f'http://{self.bondIp}/v2/devices/{deviceId}/actions/{action}', headers={'BOND-Token': self.bondToken}, json=payload)
+        if r.status_code < 200 or r.status_code > 299:
+            raise Exception(r.content)
         return r.content
 
     def getDeviceIds(self):
@@ -48,6 +76,11 @@ class Bond:
         r = requests.get(f'http://{self.bondIp}/v2/devices/{deviceId}',
                          headers={'BOND-Token': self.bondToken})
         return r.json()['type']
+
+    def getProperties(self, deviceId):
+        r = requests.get(f'http://{self.bondIp}/v2/devices/{deviceId}/properties/',
+                         headers={'BOND-Token': self.bondToken})
+        return r.json()
 
     def getDevice(self, deviceId):
         r = requests.get(f'http://{self.bondIp}/v2/devices/{deviceId}',

--- a/custom_components/bond/bond.py
+++ b/custom_components/bond/bond.py
@@ -53,6 +53,15 @@ class Bond:
     def turnLightOff(self, deviceId):
         return self.doAction(deviceId, BOND_DEVICE_ACTION_TURNLIGHTOFF)
 
+    def openShade(self, deviceId):
+        return self.doAction(deviceId, BOND_DEVICE_ACTION_OPEN)
+
+    def closeShade(self, deviceId):
+        return self.doAction(deviceId, BOND_DEVICE_ACTION_CLOSE)
+
+    def holdShade(self, deviceId):
+        return self.doAction(deviceId, BOND_DEVICE_ACTION_HOLD)
+
     def doAction(self, deviceId, action, payload={}):
         r = requests.put(
             f'http://{self.bondIp}/v2/devices/{deviceId}/actions/{action}', headers={'BOND-Token': self.bondToken}, json=payload)

--- a/custom_components/bond/bond.py
+++ b/custom_components/bond/bond.py
@@ -35,11 +35,14 @@ class Bond:
         self.bondIp = bondIp
         self.bondToken = bondToken
 
-    def turnFanOn(self, deviceId):
+    def turnOn(self, deviceId):
         return self.doAction(deviceId, BOND_DEVICE_ACTION_TURNON)
 
-    def turnFanOff(self, deviceId):
+    def turnOff(self, deviceId):
         return self.doAction(deviceId, BOND_DEVICE_ACTION_TURNOFF)
+
+    def togglePower(self, deviceId):
+        return self.doAction(deviceId, BOND_DEVICE_ACTION_TOGGLEPOWER)
 
     def setFanSpeed(self, deviceId, speed):
         return self.doAction(deviceId, BOND_DEVICE_ACTION_SETSPEED, {"argument":speed} )

--- a/custom_components/bond/cover.py
+++ b/custom_components/bond/cover.py
@@ -1,0 +1,92 @@
+"""Bond Home Motorized Shade Integration"""
+from homeassistant.components.cover import (
+    SERVICE_OPEN_COVER,
+    SERVICE_CLOSE_COVER,
+    SERVICE_STOP_COVER,
+    SERVICE_TOGGLE,
+    SUPPORT_OPEN,
+    SUPPORT_CLOSE,
+    SUPPORT_STOP,
+    STATE_CLOSED,
+    STATE_OPEN,
+    CoverDevice,
+)
+
+import logging
+DOMAIN = 'bond'
+
+from .bond import (
+    BOND_DEVICE_TYPE_MOTORIZED_SHADES,
+    BOND_DEVICE_ACTION_OPEN,
+    BOND_DEVICE_ACTION_CLOSE,
+    BOND_DEVICE_ACTION_HOLD,
+    BOND_DEVICE_ACTION_PAIR,
+    BOND_DEVICE_ACTION_PRESET,
+    BOND_DEVICE_ACTION_TOGGLEOPEN,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the Bond Fan platform"""
+    # Setup connection with devices/cloud
+    bond = hass.data[DOMAIN]['bond_hub']
+
+    # Add devices
+    for deviceId in bond.getDeviceIds():
+        newBondCover = BondCover(bond, deviceId)
+
+        # If not Motorized Shaed device, do not instatiate object
+        if newBondCover._device['type'] == BOND_DEVICE_TYPE_MOTORIZED_SHADES:
+            add_entities( [ newBondCover ] )
+
+class BondCover(CoverDevice):
+    """Representation of an Bond Shade"""
+
+    def __init__(self, bond, deviceId):
+        """Initialize a Bond Fan"""
+        self._bond = bond
+        self._deviceId = deviceId
+        self._device = self._bond.getDevice(self._deviceId)
+        self._properties = self._bond.getProperties(self._deviceId)
+        self._name = self._device['name']
+        self._state = None
+
+    @property
+    def name(self):
+        """Return the display name of this fan"""
+        return self._name
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        supported_features = SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_STOP
+        return supported_features
+
+    @property
+    def is_closed(self):
+        bondState = self._bond.getDeviceState(self._deviceId)
+        if 'open' in bondState:
+            return bondState['open'] == 0
+
+    @property
+    def state(self):
+        if self.is_closed:
+            return STATE_CLOSED
+        else:
+            return STATE_OPEN
+
+    def open_cover(self, **kwargs):
+        """Instruct the cover to open."""
+        self._bond.openShade(self._deviceId)
+
+    def close_cover(self, **kwargs):
+        """Instruct the cover to close."""
+        self._bond.closeShade(self._deviceId)
+
+    def stop_cover(self, **kwargs):
+        """Instruct the cover to stop."""
+        self._bond.holdShade(self._deviceId)
+
+

--- a/custom_components/bond/fan.py
+++ b/custom_components/bond/fan.py
@@ -33,7 +33,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     # Add devices
     for deviceId in bond.getDeviceIds():
         newBondFan = BondFan(bond, deviceId)
-        if newBondFan is not None:
+
+        # If not Ceiling Fan type, do not instatiate object
+        if newBondFan._device['type'] == BOND_DEVICE_TYPE_CEILING_FAN:
             add_entities( [ newBondFan ] )
 
 class BondFan(FanEntity):
@@ -49,20 +51,16 @@ class BondFan(FanEntity):
         self._state = None
         self._speed_list = []
 
-        if self._device['type'] == BOND_DEVICE_TYPE_CEILING_FAN:
-            if BOND_DEVICE_ACTION_SETSPEED in self._device['actions']:
-                if 'max_speed' in self._properties:
-                    self._speed_high = int(self._properties['max_speed'])
-                    self._speed_low = int(1)
-                    self._speed_list.append(SPEED_LOW)
-                    if self._speed_high > 2:
-                        self._speed_list.append(SPEED_MEDIUM)
-                        self._speed_medium = (self._speed_high + 1) // 2
-                        self._speed_list.append(SPEED_MEDIUM)
-                    self._speed_list.append(SPEED_HIGH)
-        else:
-            # If not Ceiling Fan type, do not instatiate object
-            self = None
+        if BOND_DEVICE_ACTION_SETSPEED in self._device['actions']:
+            if 'max_speed' in self._properties:
+                self._speed_high = int(self._properties['max_speed'])
+                self._speed_low = int(1)
+                self._speed_list.append(SPEED_LOW)
+                if self._speed_high > 2:
+                    self._speed_list.append(SPEED_MEDIUM)
+                    self._speed_medium = (self._speed_high + 1) // 2
+                    self._speed_list.append(SPEED_MEDIUM)
+                self._speed_list.append(SPEED_HIGH)
             
     @property
     def name(self):
@@ -111,4 +109,5 @@ class BondFan(FanEntity):
         This is the only method that should fetch new data for Home Assistant
         """
         bondState = self._bond.getDeviceState(self._deviceId)
+        # if 'power' in bondState:
         self._state = True if bondState['power'] == 1 else False

--- a/custom_components/bond/fan.py
+++ b/custom_components/bond/fan.py
@@ -89,11 +89,11 @@ class BondFan(FanEntity):
 
     def turn_on(self, speed=None, **kwargs):
         """Instruct the fan to turn on"""
-        self._bond.turnFanOn(self._deviceId)
+        self._bond.turnOn(self._deviceId)
 
     def turn_off(self, **kwargs):
         """Instruct the fan to turn off"""
-        self._bond.turnFanOff(self._deviceId)
+        self._bond.turnOff(self._deviceId)
 
     def set_speed(self, speed: str) -> None:
         """Set the speed of the fan."""

--- a/custom_components/bond/fan.py
+++ b/custom_components/bond/fan.py
@@ -109,5 +109,5 @@ class BondFan(FanEntity):
         This is the only method that should fetch new data for Home Assistant
         """
         bondState = self._bond.getDeviceState(self._deviceId)
-        # if 'power' in bondState:
-        self._state = True if bondState['power'] == 1 else False
+        if 'power' in bondState:
+            self._state = True if bondState['power'] == 1 else False

--- a/custom_components/bond/fan.py
+++ b/custom_components/bond/fan.py
@@ -3,6 +3,10 @@ from homeassistant.components.fan import (FanEntity)
 import logging
 DOMAIN = 'bond'
 
+from .bond import (
+    BOND_DEVICE_TYPE_CEILING_FAN,
+)
+
 # Import the device class from the component that you want to support
 
 _LOGGER = logging.getLogger(__name__)
@@ -14,7 +18,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     bond = hass.data[DOMAIN]['bond_hub']
 
     # Add devices
-    add_entities(BondFan(bond, deviceId) for deviceId in bond.getDeviceIds())
+    for deviceId in bond.getDeviceIds():
+        if bond.getDeviceType(deviceId) == BOND_DEVICE_TYPE_CEILING_FAN:
+            add_entities( [ BondFan(bond, deviceId) ] )
 
 
 class BondFan(FanEntity):

--- a/custom_components/bond/fan.py
+++ b/custom_components/bond/fan.py
@@ -1,10 +1,23 @@
 """Bond Home Fan Integration"""
-from homeassistant.components.fan import (FanEntity)
+from homeassistant.components.fan import (
+    SUPPORT_SET_SPEED,
+    SPEED_LOW,
+    SPEED_MEDIUM,
+    SPEED_HIGH,
+    FanEntity
+)
 import logging
 DOMAIN = 'bond'
 
 from .bond import (
     BOND_DEVICE_TYPE_CEILING_FAN,
+    BOND_DEVICE_ACTION_SETSPEED,
+    BOND_DEVICE_ACTION_INCREASESPEED,
+    BOND_DEVICE_ACTION_DECREASESPEED,
+    BOND_DEVICE_ACTION_TURNON,
+    BOND_DEVICE_ACTION_TURNOFF,
+    BOND_DEVICE_ACTION_TOGGLEPOWER,
+
 )
 
 # Import the device class from the component that you want to support
@@ -22,7 +35,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         if bond.getDeviceType(deviceId) == BOND_DEVICE_TYPE_CEILING_FAN:
             add_entities( [ BondFan(bond, deviceId) ] )
 
-
 class BondFan(FanEntity):
     """Representation of an Bond Fan"""
 
@@ -30,10 +42,22 @@ class BondFan(FanEntity):
         """Initialize a Bond Fan"""
         self._bond = bond
         self._deviceId = deviceId
+        self._device = self._bond.getDevice(self._deviceId)
+        self._properties = self._bond.getProperties(self._deviceId)
+        self._speed_list = []
 
-        bondProperties = self._bond.getDevice(self._deviceId)
-
-        self._name = bondProperties['name']
+        if BOND_DEVICE_ACTION_SETSPEED in self._device['actions']:
+            if 'max_speed' in self._properties:
+                self._speed_high = int(self._properties['max_speed'])
+                self._speed_low = int(1)
+                self._speed_list.append(SPEED_LOW)
+                if self._speed_high > 2:
+                    self._speed_list.append(SPEED_MEDIUM)
+                    self._speed_medium = (self._speed_high + 1) // 2
+                    self._speed_list.append(SPEED_MEDIUM)
+                self._speed_list.append(SPEED_HIGH)
+                
+        self._name = self._device['name']
         self._state = None
 
     @property
@@ -46,6 +70,21 @@ class BondFan(FanEntity):
         """Return true if fan is on"""
         return self._state
 
+    @property
+    def speed_list(self) -> list:
+        """Get the list of available speeds."""
+        return self._speed_list
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        supported_features = 0
+
+        if BOND_DEVICE_ACTION_SETSPEED in self._device['actions']:
+            supported_features |= SUPPORT_SET_SPEED
+
+        return supported_features
+
     def turn_on(self, speed=None, **kwargs):
         """Instruct the fan to turn on"""
         self._bond.turnFanOn(self._deviceId)
@@ -53,6 +92,15 @@ class BondFan(FanEntity):
     def turn_off(self, **kwargs):
         """Instruct the fan to turn off"""
         self._bond.turnFanOff(self._deviceId)
+
+    def set_speed(self, speed: str) -> None:
+        """Set the speed of the fan."""
+        if speed == SPEED_HIGH:
+           self._bond.setFanSpeed(self._deviceId, self._speed_high)
+        elif speed == SPEED_MEDIUM:
+           self._bond.setFanSpeed(self._deviceId, self._speed_medium)
+        elif speed == SPEED_LOW:
+           self._bond.setFanSpeed(self._deviceId, self._speed_low)
 
     def update(self):
         """Fetch new state data for this fan

--- a/custom_components/bond/light.py
+++ b/custom_components/bond/light.py
@@ -4,6 +4,11 @@ from homeassistant.components.light import (
 import logging
 DOMAIN = 'bond'
 
+from .bond import (
+    BOND_DEVICE_TYPE_CEILING_FAN,
+)
+
+
 # Import the device class from the component that you want to support
 
 _LOGGER = logging.getLogger(__name__)
@@ -20,8 +25,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     #     return
 
     # Add devices
-    add_entities(BondLight(bond, deviceId) for deviceId in bond.getDeviceIds())
-
+    for deviceId in bond.getDeviceIds():
+        if bond.getDeviceType(deviceId) == BOND_DEVICE_TYPE_CEILING_FAN:
+            add_entities( [ BondLight(bond, deviceId) ] )
 
 class BondLight(Light):
     """Representation of an Bond Light."""

--- a/custom_components/bond/light.py
+++ b/custom_components/bond/light.py
@@ -29,10 +29,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     # Add devices
     for deviceId in bond.getDeviceIds():
-        if bond.getDeviceType(deviceId) == BOND_DEVICE_TYPE_CEILING_FAN:
-            newBondLight = BondLight(bond, deviceId)
-            if newBondLight is not None:
-                add_entities( [ newBondLight ] )
+        newBondLight = BondLight(bond, deviceId)
+        if newBondLight is not None:
+            add_entities( [ newBondLight ] )
 
 class BondLight(Light):
     """Representation of an Bond Light."""
@@ -42,13 +41,15 @@ class BondLight(Light):
         self._bond = bond
         self._deviceId = deviceId
         self._properties = self._bond.getDevice(self._deviceId)
+        self._name = self._properties['name'] + ' Light'
+        self._state = None
 
-        if BOND_DEVICE_ACTION_TURNLIGHTON in self._properties['actions'] or BOND_DEVICE_ACTION_TURNLIGHTOFF in self._properties['actions'] or BOND_DEVICE_ACTION_TOGGLELIGHT in self._properties['actions']:
-            self._name = self._properties['name'] + ' Light'
-            self._state = None
-            # self._brightness = None
-        else:
-            # If Bond device does not support on/off or toggle, it's probably not a light 
+        # If the device type is not Ceiling Fan, or it is Ceiling Fan but has no action for light control
+        # then don't create a light instance
+        if self._properties['type'] != BOND_DEVICE_TYPE_CEILING_FAN or \
+             ( BOND_DEVICE_ACTION_TURNLIGHTON not in self._properties['actions'] and \
+               BOND_DEVICE_ACTION_TURNLIGHTOFF not in self._properties['actions'] and \
+               BOND_DEVICE_ACTION_TOGGLELIGHT not in self._properties['actions'] ):
             self = None
 
     @property

--- a/custom_components/bond/switch.py
+++ b/custom_components/bond/switch.py
@@ -1,0 +1,72 @@
+"""Bond Home Generic Device Integration"""
+from homeassistant.components.switch import (
+    STATE_ON,
+    SERVICE_TURN_ON,
+    SERVICE_TURN_OFF,
+    SERVICE_TOGGLE,
+    SwitchDevice,
+)
+import logging
+DOMAIN = 'bond'
+
+from .bond import (
+    BOND_DEVICE_TYPE_GENERIC_DEVICE,
+    BOND_DEVICE_ACTION_TURNON,
+    BOND_DEVICE_ACTION_TURNOFF,
+    BOND_DEVICE_ACTION_TOGGLEPOWER,
+)
+
+# Import the device class from the component that you want to support
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the Bond Generic Device platform."""
+    # Setup connection with devices/cloud
+    bond = hass.data[DOMAIN]['bond_hub']
+
+    # Add devices
+    for deviceId in bond.getDeviceIds():
+        newBondSwitch = BondSwitch(bond, deviceId)
+
+        # If the device type is not a Generic Device, then don't create a switch instance
+        if newBondSwitch._properties['type'] == BOND_DEVICE_TYPE_GENERIC_DEVICE:
+            add_entities( [ newBondSwitch ] )
+
+class BondSwitch(SwitchDevice):
+    """Representation of an Bond Generic Device."""
+
+    def __init__(self, bond, deviceId):
+        """Initialize a Bond Generic Device."""
+        self._bond = bond
+        self._deviceId = deviceId
+        self._properties = self._bond.getDevice(self._deviceId)
+        self._name = self._properties['name']
+        self._state = None
+
+    @property
+    def name(self):
+        """Return the display name of this light."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return true if switch is on."""
+        return self._state
+
+    def turn_on(self, **kwargs):
+        """Instruct the Generic Device to turn on."""
+        self._bond.turnOn(self._deviceId)
+
+    def turn_off(self, **kwargs):
+        """Instruct the Generic Device to turn off."""
+        self._bond.turnOff(self._deviceId)
+
+    def update(self):
+        """Fetch new state data for this light.
+        This is the only method that should fetch new data for Home Assistant.
+        """
+        bondState = self._bond.getDeviceState(self._deviceId)
+        if 'power' in bondState:
+            self._state = True if bondState['power'] == 1 else False


### PR DESCRIPTION
Added support for Bond "Generic Devices" - this is the type of control Bond creates if you are using a very basic RF remote controlled switch.  Implemented, therefore, as a switch with On and Off controls, and status, and not much else.
At the same time, since the command to Bond for turning a generic device on or off is the same as for turning a fan on or off, I renamed bond.turnFanOn and bond.turnFanOff to bond.turnOn and bond.turnOff respectively.