### PR TITLE
Fix device names

### DIFF
--- a/custom_components/bond/cover.py
+++ b/custom_components/bond/cover.py
@@ -45,11 +45,7 @@ class BondCover(CoverDevice):
         self._deviceId = deviceId
         self._device = device
         self._properties = properties
-        name = "Cover" if "name" not in properties else properties['name']
-        if "location" in properties:
-            self._name = f"{properties['location']} {name}"
-        else:
-            self._name = name
+        self._name = device['name']
         self._state = None
 
     @property

--- a/custom_components/bond/fan.py
+++ b/custom_components/bond/fan.py
@@ -41,11 +41,7 @@ class BondFan(FanEntity):
         self._deviceId = deviceId
         self._device = device
         self._properties = properties
-        name = "Fan" if "name" not in properties else properties['name']
-        if "location" in properties:
-            self._name = f"{properties['location']} {name}"
-        else:
-            self._name = name
+        self._name = device['name']
         self._state = None
         self._speed_list = []
 

--- a/custom_components/bond/light.py
+++ b/custom_components/bond/light.py
@@ -80,11 +80,7 @@ class BondLight(Light):
         self._deviceId = deviceId
         self._device = device
         self._properties = properties
-        name = "Light" if "name" not in properties else properties['name']
-        if "location" in properties:
-            self._name = f"{properties['location']} {name}"
-        else:
-            self._name = name
+        self._name = device['name']
         self._state = None
 
     @property


### PR DESCRIPTION
I'm not sure if this changed in a recent firmware update, or this just got missed in code review/testing, but the device name is actually on the device resource itself, not /properties. Running the current version in `master`, all my devices just show up as "Fan" or "Light". I also removed appending the "location" to the name, because this is redundant for devices (like I have) named "Office Fan" in the location called "Office". It's necessary to name it "Office Fan" in the Bond app, because they will not let you have multiple devices named "Fan", even if they're in two different rooms / locations.