### PR TITLE
'current_speed' attribute addition

### DIFF
--- a/custom_components/bond/fan.py
+++ b/custom_components/bond/fan.py
@@ -102,13 +102,13 @@ class BondFan(FanEntity):
 
     def set_speed(self, speed: str) -> None:
         """Set the speed of the fan."""
-        self._attributes['current_speed'] = speed
         if speed == SPEED_HIGH:
             self._bond.setSpeed(self._deviceId, self._speed_high)
         elif speed == SPEED_MEDIUM:
             self._bond.setSpeed(self._deviceId, self._speed_medium)
         elif speed == SPEED_LOW:
             self._bond.setSpeed(self._deviceId, self._speed_low)
+        self._attributes['current_speed'] = speed
 
     def update(self):
         """Fetch new state data for this fan

--- a/custom_components/bond/fan.py
+++ b/custom_components/bond/fan.py
@@ -109,7 +109,7 @@ class BondFan(FanEntity):
         bondState = self._bond.getDeviceState(self._deviceId)
         if 'power' in bondState:
             self._state = True if bondState['power'] == 1 else False
-            self._attributes['speed'] = [speed_name for speed_name, speed_value in self._speed_map if bondState['speed'] == speed_value][0]
+            self._attributes['speed'] = [speed_name for speed_name, speed_value in self._speed_map.items() if bondState['speed'] == speed_value][0]
 
     @property
     def unique_id(self):

--- a/custom_components/bond/fan.py
+++ b/custom_components/bond/fan.py
@@ -41,8 +41,13 @@ class BondFan(FanEntity):
         self._deviceId = deviceId
         self._device = device
         self._properties = properties
-        self._name = device['name']
+        name = "Fan" if "name" not in properties else properties['name']
+        if "location" in properties:
+            self._name = f"{properties['location']} {name}"
+        else:
+            self._name = name
         self._state = None
+        self._attributes = {}
         self._speed_list = []
 
         if BOND_DEVICE_ACTION_SET_SPEED in self._device['actions']:
@@ -79,7 +84,12 @@ class BondFan(FanEntity):
             supported_features |= SUPPORT_SET_SPEED
 
         return supported_features
-
+    
+    @property
+    def device_state_attributes(self):
+        """Return state attributes """
+        return self._attributes
+    
     def turn_on(self, speed=None, **kwargs):
         """Instruct the fan to turn on"""
         self._bond.turnOn(self._deviceId)
@@ -104,6 +114,7 @@ class BondFan(FanEntity):
         bondState = self._bond.getDeviceState(self._deviceId)
         if 'power' in bondState:
             self._state = True if bondState['power'] == 1 else False
+            self._attributes['speed'] = bondState['speed'] if bondState['power'] == 1 else 0
 
     @property
     def unique_id(self):


### PR DESCRIPTION
Hello!

I've been using your integration to control my ceiling fans, and it works flawlessly! One issue I've encountered is being able to determine the current speed of the fan for a variety of uses, which in my case is to update an icon on my lovelace dashboard to represent the current setting. This PR integrates the current speed as an attribute, ensuring it's updated when a command is being sent, as well as captured when updating via the bond controller.

Let me know what you think, or if any changes should be made.

- Mike